### PR TITLE
Add setup docs and config cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# CRM Setup
+
+This project uses Laravel and React. Follow these steps to set up the environment.
+
+1. Install PHP (>= 8.2) and Composer.
+2. Run `composer install` to install PHP dependencies.
+3. Copy `.env.example` to `.env` and generate an application key:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate --ansi
+   ```
+4. Install Node dependencies:
+   ```bash
+   npm install
+   ```
+5. Create the SQLite database and run migrations:
+   ```bash
+   touch database/database.sqlite
+   php artisan migrate --ansi
+   ```
+6. Build frontend assets:
+   ```bash
+   npm run build
+   ```
+7. Start the development server if needed:
+   ```bash
+   npm run dev
+   ```
+
+A minimal `tailwind.config.js` is included referencing the `resources/` directory.

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -7,7 +7,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import {
   Rocket,
   Layers,
@@ -20,8 +19,6 @@ import {
 /**
  * ✨  Monochrome landing — palette strictly ⚫️⚪️ + greys.
  */
-const accent = "#FFFFFF"; // white accent used sparingly
-const glow = "#ffffff0d"; // subtle white glow for radial bg
 
 const fade = {
   hidden: { opacity: 0, y: 24 },
@@ -201,7 +198,7 @@ function Faqs() {
         Frequently Asked Questions
       </motion.h2>
       <div className="mx-auto max-w-2xl divide-y divide-zinc-800 px-6">
-        {faqs.map((f, i) => (
+        {faqs.map((f) => (
           <details key={f.q} className="group py-6">
             <summary className="flex cursor-pointer items-center justify-between text-lg font-medium text-white">
               {f.q}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    './resources/**/*.{js,jsx,ts,tsx,vue}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- document setup in README
- add MIT license
- configure Tailwind
- clean unused code in welcome page

## Testing
- `npm run lint`
- `php artisan migrate --ansi`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68409fa1179083289f46cab683569ae9